### PR TITLE
Include zlib only if the opts.compress flag is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
+if (opts.compress){
 const { gzip, gunzip } = require('node:zlib')
+}
 
 function connPiper (connection, _dst, opts = {}, stats = {}) {
   const loc = _dst()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-cmd-lib-net",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HyperCmd Net lib",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
This repository is causing issue with getting hyperdht to work on Mobile and on Pear as they both do not support node:zlib, which is required only in the case if compression flag is passed in the options.